### PR TITLE
Change GetSatetments logic. Make StartDate and EndDate optional

### DIFF
--- a/FinancialSummaryApi.Tests/V1/Infrastructure/Validators/GetStatementListRequestValidatorTests.cs
+++ b/FinancialSummaryApi.Tests/V1/Infrastructure/Validators/GetStatementListRequestValidatorTests.cs
@@ -4,6 +4,7 @@ using FluentValidation.TestHelper;
 using System;
 using Xunit;
 using System.Text.RegularExpressions;
+using FluentAssertions;
 
 namespace FinancialSummaryApi.Tests.V1.Infrastructure.Validators
 {
@@ -50,7 +51,7 @@ namespace FinancialSummaryApi.Tests.V1.Infrastructure.Validators
         }
 
         [Fact]
-        public void GivenMinValueForStartDate_ShouldHaveValidationError()
+        public void GivenMinValueForStartDate_ShouldBeOk()
         {
             var request = new GetStatementListRequest()
             {
@@ -62,12 +63,12 @@ namespace FinancialSummaryApi.Tests.V1.Infrastructure.Validators
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor(x => x.StartDate)
-                  .WithErrorMessage($"'{InsertSpaceBetweenWords(nameof(request.StartDate))}' must not be empty.");
+            result.IsValid.Should().BeTrue();
+            result.ShouldNotHaveValidationErrorFor(x => x.StartDate);
         }
 
         [Fact]
-        public void GivenMinValueForEndDate_ShouldHaveValidationError()
+        public void GivenMinValueForEndDate_ShouldbeOk()
         {
             var request = new GetStatementListRequest()
             {
@@ -79,8 +80,8 @@ namespace FinancialSummaryApi.Tests.V1.Infrastructure.Validators
 
             var result = _validator.TestValidate(request);
 
-            result.ShouldHaveValidationErrorFor(x => x.EndDate)
-                  .WithErrorMessage($"'{InsertSpaceBetweenWords(nameof(request.EndDate))}' must not be empty.");
+            result.IsValid.Should().BeTrue();
+            result.ShouldNotHaveValidationErrorFor(x => x.EndDate);
         }
 
         public static string InsertSpaceBetweenWords(string input)

--- a/FinancialSummaryApi/V1/Boundary/Request/GetStatementListRequest.cs
+++ b/FinancialSummaryApi/V1/Boundary/Request/GetStatementListRequest.cs
@@ -16,12 +16,12 @@ namespace FinancialSummaryApi.V1.Boundary.Request
         public int PageNumber { get; set; } = 1;
 
         /// <summary>
-        /// The start date from when we want to filter statements
+        /// The start date from when we want to filter statements. Required only if EndDate is provided
         /// </summary>
         public DateTime StartDate { get; set; }
 
         /// <summary>
-        /// The end date until when we want to filter statements
+        /// The end date until when we want to filter statements. Required only if StartDate is provided
         /// </summary>
         public DateTime EndDate { get; set; }
     }

--- a/FinancialSummaryApi/V1/Gateways/DynamoDbGateway.cs
+++ b/FinancialSummaryApi/V1/Gateways/DynamoDbGateway.cs
@@ -203,17 +203,22 @@ namespace FinancialSummaryApi.V1.Gateways
                 TableName = "FinancialSummaries",
                 IndexName = "target_id_dx",
                 KeyConditionExpression = "target_id = :V_target_id ",
-                FilterExpression = "summary_type = :V_summary_type " +
-                                  "and statement_period_end_date between :V_start_date and :V_end_date",
+                FilterExpression = "summary_type = :V_summary_type ",
                 ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                 {
                     { ":V_target_id", new AttributeValue { S = targetId.ToString() } },
                     { ":V_summary_type", new AttributeValue { S = SummaryType.Statement.ToString() } },
-                    { ":V_start_date", new AttributeValue { S = startDate.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ") } },
-                    { ":V_end_date", new AttributeValue { S = endDate.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ") } }
                 },
                 Select = Select.ALL_ATTRIBUTES
             };
+
+            if (startDate != DateTime.MinValue && endDate != DateTime.MinValue)
+            {
+                request.FilterExpression += " and statement_period_end_date between :V_start_date and :V_end_date";
+
+                request.ExpressionAttributeValues.Add(":V_start_date", new AttributeValue { S = startDate.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ") });
+                request.ExpressionAttributeValues.Add(":V_end_date", new AttributeValue { S = endDate.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffZ") });
+            }
 
             var data = await _amazonDynamoDb.QueryAsync(request).ConfigureAwait(false);
             var totalStatementsCount = data.Count;

--- a/FinancialSummaryApi/V1/Infrastructure/Validators/GetStatementListRequestValidator.cs
+++ b/FinancialSummaryApi/V1/Infrastructure/Validators/GetStatementListRequestValidator.cs
@@ -9,8 +9,6 @@ namespace FinancialSummaryApi.V1.Infrastructure.Validators
         {
             RuleFor(x => x.PageSize).GreaterThanOrEqualTo(1);
             RuleFor(x => x.PageNumber).GreaterThanOrEqualTo(1);
-            RuleFor(x => x.StartDate).NotEmpty();
-            RuleFor(x => x.EndDate).NotEmpty();
         }
     }
 }

--- a/FinancialSummaryApi/V1/UseCase/GetStatementListUseCase.cs
+++ b/FinancialSummaryApi/V1/UseCase/GetStatementListUseCase.cs
@@ -23,10 +23,13 @@ namespace FinancialSummaryApi.V1.UseCase
 
         public async Task<StatementListResponse> ExecuteAsync(Guid targetId, GetStatementListRequest request)
         {
-            var startDate = request.StartDate.Date.GetDayRange().dayStart;
-            var endDate = request.EndDate.Date.GetDayRange().dayEnd;
+            if (request.StartDate != DateTime.MinValue && request.EndDate != DateTime.MinValue)
+            {
+                request.StartDate = request.StartDate.Date.GetDayRange().dayStart;
+                request.EndDate = request.EndDate.Date.GetDayRange().dayEnd;
+            }
 
-            var statementList = await _financeSummaryGateway.GetPagedStatementsAsync(targetId, startDate, endDate, request.PageSize, request.PageNumber).ConfigureAwait(false);
+            var statementList = await _financeSummaryGateway.GetPagedStatementsAsync(targetId, request.StartDate, request.EndDate, request.PageSize, request.PageNumber).ConfigureAwait(false);
 
             var statementResponseList = _mapper.Map<List<StatementResponse>>(statementList.Statements);
 


### PR DESCRIPTION
## Link to ClickUp ticket

https://app.clickup.com/t/1px14gh

## Describe this PR

### *What is the problem we're trying to solve*

For GetStatements endpoint StartDate and EndDate params should be empty

#### _Checklist_

- [x] Modify API validation
- [x] Modify gateway to use date params only if it's provided
- [x] Update unit tests