### PR TITLE
Updated the framework version and some packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -69,7 +69,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
             apt-get -y install libgdiplus libc6-dev
             

--- a/FinancialSummaryApi.Tests/Dockerfile
+++ b/FinancialSummaryApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/FinancialSummaryApi.Tests/FinancialSummaryApi.Tests.csproj
+++ b/FinancialSummaryApi.Tests/FinancialSummaryApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -22,7 +22,7 @@
     <PackageReference Include="Hackney.Core.JWT" Version="1.66.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
 
       <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />

--- a/FinancialSummaryApi/Dockerfile
+++ b/FinancialSummaryApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/FinancialSummaryApi/FinancialSummaryApi.csproj
+++ b/FinancialSummaryApi/FinancialSummaryApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -48,21 +48,21 @@
         <PackageReference Include="Hackney.Core.JWT" Version="1.64.0" />
         <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
         <PackageReference Include="CsvHelper" Version="27.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.22" />
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.6" />
 
         <PackageReference Include="NodaMoney" Version="1.0.5" />
         <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.3" />
         <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
         <PackageReference Include="Razor.Templating.Core" Version="1.6.0" />
     </ItemGroup>
 

--- a/FinancialSummaryApi/Startup.cs
+++ b/FinancialSummaryApi/Startup.cs
@@ -53,7 +53,6 @@ namespace FinancialSummaryApi
             services.AddAutoMapper(typeof(Startup));
             services
                 .AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddFluentValidation(o => o.RegisterValidatorsFromAssemblyContaining<Startup>());
             services.AddApiVersioning(o =>
             {

--- a/FinancialSummaryApi/build.cmd
+++ b/FinancialSummaryApi/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/financial-summary-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/financial-summary-api.zip

--- a/FinancialSummaryApi/build.sh
+++ b/FinancialSummaryApi/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/financial-summary-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/financial-summary-api.zip

--- a/FinancialSummaryApi/serverless.yml
+++ b/FinancialSummaryApi/serverless.yml
@@ -1,7 +1,7 @@
 service: financial-summary-api
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   memorySize: 2048
   timeout: 300
   tracing:
@@ -12,7 +12,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/financial-summary-api.zip
+  artifact: ./bin/release/net6.0/financial-summary-api.zip
 functions:
   FinancialSummaryApi:
     name: ${self:service}-${self:provider.stage}


### PR DESCRIPTION
# What:
 - An upgrade of the dotnet version from 3.1 to 6.
 - An upgrade of some of the packages that are needed for the newer version to get deployed/run.

# Why:
 - It's a mandatory piece of work due to security as the current (3.1) version is reaching its end of life.
 - Better performance.
 - Newer features & syntax.
 
# Notes:
 - These changes have already been deployed to development environment via the editing of the config within the `du-test` branch. Making HTTP requests with Insomnia seems to suggest that the code is working as expected. The merging of this PR to development branch will simply redeploy the exact same thing, but officially.
 - And obviously, all of the automated tests were made sure to pass.