### PR TITLE
Remove 2nd authentication

### DIFF
--- a/FinancialSummaryApi.Tests/DynamoDbIntegrationTests.cs
+++ b/FinancialSummaryApi.Tests/DynamoDbIntegrationTests.cs
@@ -10,8 +10,6 @@ namespace FinancialSummaryApi.Tests
 {
     public class DynamoDbIntegrationTests<TStartup> : IDisposable where TStartup : class
     {
-        private const string TestToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNjM5NDIyNzE4LCJleHAiOjE5ODY1Nzc5MTgsImF1ZCI6InRlc3QiLCJzdWIiOiJ0ZXN0IiwiZ3JvdXBzIjpbInNvbWUtdmFsaWQtZ29vZ2xlLWdyb3VwIiwic29tZS1vdGhlci12YWxpZC1nb29nbGUtZ3JvdXAiXSwibmFtZSI6InRlc3RpbmcifQ.IcpQ00PGVgksXkR_HFqWOakgbQ_PwW9dTVQu4w77tmU";
-
         protected HttpClient Client { get; private set; }
         private readonly DynamoDbMockWebApplicationFactory<TStartup> _factory;
         protected IDynamoDBContext DynamoDbContext => _factory?.DynamoDbContext;
@@ -44,8 +42,6 @@ namespace FinancialSummaryApi.Tests
             EnsureEnvVarConfigured("DynamoDb_LocalSecretKey", "8kmm3g");
             EnsureEnvVarConfigured("DynamoDb_LocalAccessKey", "fco1i2");
 
-            EnsureEnvVarConfigured("REQUIRED_GOOGL_GROUPS", "some-valid-google-group");
-
             EnsureEnvVarConfigured("Header", "Header");
             EnsureEnvVarConfigured("SubHeader", "SubHeader");
             EnsureEnvVarConfigured("Footer", "Footer");
@@ -53,7 +49,6 @@ namespace FinancialSummaryApi.Tests
             _factory = new DynamoDbMockWebApplicationFactory<TStartup>(_tables);
 
             Client = _factory.CreateClient();
-            Client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(TestToken);
             CleanupActions = new List<Action>();
         }
 

--- a/FinancialSummaryApi.Tests/FinancialSummaryApi.Tests.csproj
+++ b/FinancialSummaryApi.Tests/FinancialSummaryApi.Tests.csproj
@@ -18,8 +18,6 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Hackney.Core.Authorization" Version="1.66.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.66.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />

--- a/FinancialSummaryApi/FinancialSummaryApi.csproj
+++ b/FinancialSummaryApi/FinancialSummaryApi.csproj
@@ -41,7 +41,6 @@
         <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.2" />
         <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
         <PackageReference Include="AWSXRayRecorder.Handlers.EntityFramework" Version="1.1.0" />
-        <PackageReference Include="Hackney.Core.Authorization" Version="1.64.0" />
         <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />
         <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
 

--- a/FinancialSummaryApi/Startup.cs
+++ b/FinancialSummaryApi/Startup.cs
@@ -8,9 +8,7 @@ using FinancialSummaryApi.V1.UseCase;
 using FinancialSummaryApi.V1.UseCase.Interfaces;
 using FinancialSummaryApi.Versioning;
 using FluentValidation.AspNetCore;
-using Hackney.Core.Authorization;
 using Hackney.Core.Http;
-using Hackney.Core.JWT;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -123,8 +121,7 @@ namespace FinancialSummaryApi
             ConfigureLogging(services, Configuration);
 
             services.ConfigureDynamoDB();
-            services.AddTokenFactory()
-                .AddHttpContextWrapper();
+            services.AddHttpContextWrapper();
 
             RegisterGateways(services);
             RegisterUseCases(services);
@@ -223,7 +220,6 @@ namespace FinancialSummaryApi
 
             app.UseSwagger();
             app.UseRouting();
-            app.UseGoogleGroupAuthorization();
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseEndpoints(endpoints =>
             {

--- a/FinancialSummaryApi/serverless.yml
+++ b/FinancialSummaryApi/serverless.yml
@@ -19,7 +19,6 @@ functions:
     handler: FinancialSummaryApi::FinancialSummaryApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
     environment:
-     REQUIRED_GOOGL_GROUPS: ${ssm:/housing-finance/${self:provider.stage}/authorization/required-google-groups}
      Header: ${ssm:/housing-finance/${self:provider.stage}/report_export_settings_header}
      SubHeader: ${ssm:/housing-finance/${self:provider.stage}/report_export_settings_sub_header}
      Footer: ${ssm:/housing-finance/${self:provider.stage}/report_export_settings_footer}


### PR DESCRIPTION
# What:
 - Removed a Google Group Auth middleware.

# Why:
 - The Hackney APIs are already configured with an external authorizer. So this 2nd layer of auth would very likely create the same error as mentioned in this [PR](https://github.com/LBHackney-IT/account-api/pull/101#issue-1340396432).